### PR TITLE
Fetch existing comments using for each method

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ I made use of the following documentation and blog post resources when putting t
 
 and StackOverflow for the occasional perplexing error message and CSS tricks
 
+### Discussion Topics
+
+Here's a brief reminder-list of design choices that I think merit discussion in person.
+
+- Association of plays to comments (handling on frontend vs. backend)
+
 ## Quick dev/demo mode setup
 
 All commands below are written with the working directory as the root of this repository

--- a/frontend/playlist-frontend/src/app/comment.service.ts
+++ b/frontend/playlist-frontend/src/app/comment.service.ts
@@ -25,13 +25,13 @@ export class CommentService {
         // 'Authorization': 'my-auth-token'
       })
     };
-    const now =  new Date().toISOString();
+    const now = new Date().toISOString();
     const data = {
       comment_text: commentText,
       play_id: playID,
       author: authorID,
       last_updated: now,
-      date_created: now,
+      date_created: now
     };
     return this.http.post<any>(url, data, options).pipe(
       catchError(this.handleError<any>(`createNewComment`))

--- a/frontend/playlist-frontend/src/app/models/play.ts
+++ b/frontend/playlist-frontend/src/app/models/play.ts
@@ -9,14 +9,19 @@ export class Play {
     'release': any;
     releaseevent: any;
     track: any;
-    comment: Comment; // this app's comments? (maybe merge this with comments[])
     label: any;
-    comments: any[];
+    comments: any[]; // KEXP's actual comments
+    comment: Comment; // comments introduced by this app (these may be merged eventually)
     showid: number;
 }
 
 export class Comment {
-    commentText: string;
+    id: number;
+    'comment_text': string;
+    'play_id': number;
+    'date_created': string; // Date.toISOString()
+    'last_updated': string; // Date.toISOString()
+    author: number; // author id
 }
 
 export class Author {

--- a/frontend/playlist-frontend/src/app/playlist-item/playlist-item.component.html
+++ b/frontend/playlist-frontend/src/app/playlist-item/playlist-item.component.html
@@ -37,7 +37,11 @@
         </mat-card-header>
         <mat-card-content class="comment-form-section">
             <form [formGroup]="commentForm">
-                <mat-form-field class="full-width-comment"
+                <div *ngIf="play.comment" class="existing-comment">
+                    {{play.comment.comment_text}}
+                </div>
+                <mat-form-field *ngIf="!play.comment"
+                    class="full-width-comment"
                     floatLabel="always">
                     <mat-label>DJ Comment</mat-label>
                     <textarea

--- a/frontend/playlist-frontend/src/app/playlist/playlist.component.ts
+++ b/frontend/playlist-frontend/src/app/playlist/playlist.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Play } from '../models/play';
 import { PlaylistService } from '../playlist.service';
+import { CommentService } from '../comment.service';
 
 @Component({
   selector: 'app-playlist',
@@ -10,14 +11,36 @@ import { PlaylistService } from '../playlist.service';
 export class PlaylistComponent implements OnInit {
   recentPlays: Play[];
 
-  constructor(private playlistService: PlaylistService) { }
+  constructor(
+    private playlistService: PlaylistService,
+    private commentService: CommentService
+    ) { }
 
   ngOnInit() {
     const now = new Date();
     const then = new Date(now.getTime() - (60 * 60000));
     this.playlistService.getRecentPlays(then, now).subscribe(
-      response => {
-        this.recentPlays = response.results;
+      playlistResponse => {
+        // now fetch all the comments
+        console.log(playlistResponse);
+        const playIds = [];
+        playlistResponse.results.forEach(play => {
+          playIds.push(play.playid);
+        });
+        this.commentService.getCommentsByPlayIds(playIds).subscribe(
+          commentResponse => {
+            console.log(commentResponse);
+            commentResponse.results.forEach(comment => {
+              playlistResponse.results.forEach(play => {
+                if (play.playid === comment.play_id) {
+                  play.comment = comment;
+                }
+              });
+            });
+            console.log(playlistResponse.results);
+            this.recentPlays = playlistResponse.results;
+          }
+        );
       }
     );
   }


### PR DESCRIPTION
Fetches plays along with their existing comments, ALL from the frontend

I have some issues with this approach from an architecture standpoint, I'll be tagging this PR in the README as a reminder to go over the tradeoffs between doing this on the frontend vs. making a single request to the backend to fetch "playlist data" and have it handle associating plays with comments (and authors, links, etc)