### PR TITLE
Implement author selection and localstorage persistence

### DIFF
--- a/frontend/playlist-frontend/src/app/app.module.ts
+++ b/frontend/playlist-frontend/src/app/app.module.ts
@@ -10,13 +10,15 @@ import { HttpClientModule, HttpClientXsrfModule, HTTP_INTERCEPTORS } from '@angu
 import { ReactiveFormsModule } from '@angular/forms';
 import { PlaylistItemComponent } from './playlist-item/playlist-item.component';
 import { HttpXsrfInterceptor } from './custom-interceptor';
+import { AuthorDialogComponent } from './author-dialog/author-dialog.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     NavbarComponent,
     PlaylistComponent,
-    PlaylistItemComponent
+    PlaylistItemComponent,
+    AuthorDialogComponent
   ],
   imports: [
     BrowserModule,
@@ -28,7 +30,9 @@ import { HttpXsrfInterceptor } from './custom-interceptor';
     }),
     AppMaterialModule,
     ReactiveFormsModule
-
+  ],
+  entryComponents: [
+    AuthorDialogComponent
   ],
   providers: [
     {provide: HTTP_INTERCEPTORS, useClass: HttpXsrfInterceptor, multi: true}

--- a/frontend/playlist-frontend/src/app/author-dialog/author-dialog.component.html
+++ b/frontend/playlist-frontend/src/app/author-dialog/author-dialog.component.html
@@ -1,0 +1,19 @@
+<h1 mat-dialog-title class="mat-h1">Welcome to the KEXP DJ playlist tool</h1>
+<h3 class="mat-h3">Select your name below to begin adding comments</h3>
+<mat-dialog-content>
+  <button *ngFor="let author of authors"
+    (click)="selectAuthor(author)"
+    mat-raised-button
+    color="primary">
+    {{author.first_name}} {{author.last_name}}
+  </button>
+</mat-dialog-content>
+<mat-dialog-actions
+  align="end">
+  <button (click)="skipAuthor()"
+    mat-raised-button
+    color="accent"
+    mat-dialog-close>
+    Skip
+  </button>
+</mat-dialog-actions>

--- a/frontend/playlist-frontend/src/app/author-dialog/author-dialog.component.scss
+++ b/frontend/playlist-frontend/src/app/author-dialog/author-dialog.component.scss
@@ -1,0 +1,8 @@
+.mat-dialog-content {
+
+    .mat-raised-button {
+        width: 80%;
+        text-align: start;
+        margin-bottom: 8px;
+    }
+}

--- a/frontend/playlist-frontend/src/app/author-dialog/author-dialog.component.spec.ts
+++ b/frontend/playlist-frontend/src/app/author-dialog/author-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AuthorDialogComponent } from './author-dialog.component';
+
+describe('AuthorDialogComponent', () => {
+  let component: AuthorDialogComponent;
+  let fixture: ComponentFixture<AuthorDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AuthorDialogComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AuthorDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/playlist-frontend/src/app/author-dialog/author-dialog.component.ts
+++ b/frontend/playlist-frontend/src/app/author-dialog/author-dialog.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
+import { AuthorService } from '../author.service';
+import { Author } from '../models/play';
+
+@Component({
+  selector: 'app-author-dialog',
+  templateUrl: './author-dialog.component.html',
+  styleUrls: ['./author-dialog.component.scss']
+})
+export class AuthorDialogComponent implements OnInit {
+  authors: Author[];
+
+  constructor(
+    public dialogRef: MatDialogRef<AuthorDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    private authorService: AuthorService
+  ) {
+    this.authors = this.data.authors.sort((author1, author2) => {
+      return author1.last_name.localeCompare(author2.last_name);
+    });
+  }
+
+  ngOnInit() {
+  }
+
+  selectAuthor(selectedAuthor: Author) {
+    this.authorService.setCurrentAuthor(selectedAuthor);
+    this.dialogRef.close();
+  }
+
+  skipAuthor() {
+    const defaultAuthor = this.authors.find(author => author.role === 'admin');
+    this.authorService.setCurrentAuthor(defaultAuthor);
+  }
+
+}

--- a/frontend/playlist-frontend/src/app/author.service.spec.ts
+++ b/frontend/playlist-frontend/src/app/author.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthorService } from './author.service';
+
+describe('AuthorService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: AuthorService = TestBed.get(AuthorService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/playlist-frontend/src/app/author.service.ts
+++ b/frontend/playlist-frontend/src/app/author.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment.prod';
+import { HttpClient } from '@angular/common/http';
+import { catchError } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { Author } from './models/play';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthorService {
+  currentAuthor: Author;
+
+  constructor(private http: HttpClient) { }
+
+
+  /**
+   * Sets the current author
+   * @param newAuthor: the new author to set to the current author
+   */
+  setCurrentAuthor(newAuthor: Author) {
+    this.currentAuthor = newAuthor;
+    // save author to localstorage
+    localStorage.setItem('KEXPPlaylistCurrentAuthor', JSON.stringify(this.currentAuthor));
+  }
+
+  /**
+   * Gets the current author
+   */
+  getCurrentAuthor() {
+    return this.currentAuthor;
+  }
+
+  /**
+   * Gets all authors from the backend API
+   */
+  getAllAuthors() {
+    const url = `${environment.backendHost}/${environment.commentAPIRoot}/authors/`;
+    return this.http.get(url).pipe(
+      catchError(this.handleError<any>(`getAllAuthors`))
+    );
+  }
+
+  private handleError<T>(operation = 'operation', result?: T) {
+    return (error: any): Observable<T> => {
+      console.log(error);
+      console.log(`${operation} failed: ${error.message}`);
+      // let the app keep running by returning an empty result
+      return of(result as T);
+    };
+  }
+}

--- a/frontend/playlist-frontend/src/app/models/play.ts
+++ b/frontend/playlist-frontend/src/app/models/play.ts
@@ -21,10 +21,13 @@ export class Comment {
     'play_id': number;
     'date_created': string; // Date.toISOString()
     'last_updated': string; // Date.toISOString()
-    author: number; // author id
+    author: Author; // author id
 }
 
 export class Author {
+    id: number;
     firstName: string;
     lastName: string;
+    role: string;
+    'total_comments': number;
 }

--- a/frontend/playlist-frontend/src/app/playlist-item/playlist-item.component.ts
+++ b/frontend/playlist-frontend/src/app/playlist-item/playlist-item.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { Play } from '../models/play';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { CommentService } from '../comment.service';
+import { AuthorService } from '../author.service';
 
 @Component({
   selector: 'app-playlist-item',
@@ -16,6 +17,7 @@ export class PlaylistItemComponent implements OnInit {
 
   constructor(
     private commentService: CommentService,
+    private authorService: AuthorService,
     private fb: FormBuilder
   ) { }
 
@@ -30,18 +32,21 @@ export class PlaylistItemComponent implements OnInit {
 
   onCommentSave() {
     const text = this.commentForm.value.commentText;
+    const currentAuthor = this.authorService.getCurrentAuthor();
     if (this.play.comment) {
-      this.commentService.updateComment(this.play.comment.id, text, 1).subscribe(
+      this.commentService.updateComment(this.play.comment.id, text, currentAuthor.id).subscribe(
         newComment => {
           this.play.comment = newComment;
+          this.play.comment.author = currentAuthor;
           this.commentEditorVisible = false;
           this.commentForm.reset({commentText: this.play.comment.comment_text});
         }
       );
     } else {
-      this.commentService.createNewComment(this.play.playid, text, 1).subscribe(
+      this.commentService.createNewComment(this.play.playid, text, currentAuthor.id).subscribe(
         updatedComment => {
           this.play.comment = updatedComment;
+          this.play.comment.author = currentAuthor;
           this.commentEditorVisible = false;
           this.commentForm.reset({commentText: this.play.comment.comment_text});
         }

--- a/frontend/playlist-frontend/src/app/playlist/playlist.component.ts
+++ b/frontend/playlist-frontend/src/app/playlist/playlist.component.ts
@@ -1,7 +1,11 @@
-import { Component, OnInit } from '@angular/core';
-import { Play } from '../models/play';
+import { Component, OnInit, Inject } from '@angular/core';
+import { Play, Author } from '../models/play';
 import { PlaylistService } from '../playlist.service';
 import { trigger, style, state, transition, animate } from '@angular/animations';
+import { MatDialog } from '@angular/material';
+import { AuthorDialogComponent } from '../author-dialog/author-dialog.component';
+import { CommentService } from '../comment.service';
+import { AuthorService } from '../author.service';
 
 @Component({
   selector: 'app-playlist',
@@ -24,12 +28,30 @@ import { trigger, style, state, transition, animate } from '@angular/animations'
 export class PlaylistComponent implements OnInit {
   recentPlays: Play[];
   currentShow: any;
+  currentAuthor: Author;
 
   constructor(
-    private playlistService: PlaylistService
+    private playlistService: PlaylistService,
+    private authorService: AuthorService,
+    public dialog: MatDialog
   ) { }
 
   ngOnInit() {
+    const authorLocal = JSON.parse(localStorage.getItem('KEXPPlaylistCurrentAuthor'));
+    if (authorLocal) {
+      this.authorService.setCurrentAuthor(authorLocal);
+    } else {
+      // open author dialog
+      this.authorService.getAllAuthors().subscribe(
+        authorsResponse => {
+          this.dialog.open(AuthorDialogComponent, {
+            data: {
+              authors: authorsResponse.results
+            }
+          });
+        }
+      );
+    }
     this.playlistService.getRecentPlaysFromBackend().subscribe(
       response => {
         this.recentPlays = response.results;

--- a/frontend/playlist-frontend/src/app/shared/material/app-material.module.ts
+++ b/frontend/playlist-frontend/src/app/shared/material/app-material.module.ts
@@ -18,7 +18,8 @@ import {
   MatCardModule,
   MatChipsModule,
   MatInputModule,
-  MatFormFieldModule
+  MatFormFieldModule,
+  MatDialogModule
 } from '@angular/material';
 import { CommonModule } from '@angular/common';
 
@@ -31,7 +32,8 @@ import { CommonModule } from '@angular/common';
     MatCardModule,
     MatChipsModule,
     MatInputModule,
-    MatFormFieldModule
+    MatFormFieldModule,
+    MatDialogModule
   ],
   exports: [
     MatSidenavModule,
@@ -41,7 +43,8 @@ import { CommonModule } from '@angular/common';
     MatCardModule,
     MatChipsModule,
     MatInputModule,
-    MatFormFieldModule
+    MatFormFieldModule,
+    MatDialogModule
   ]
 })
 export class AppMaterialModule { }


### PR DESCRIPTION
Implements UI functionality to support choosing a current author using the app.

Saves the current author to localstorage with the key 'KEXPPlaylistCurrentAuthor' to persist between refreshes.

The current author-selection UI is clunky, to be addressed in a later PR